### PR TITLE
Be consistent in spelling. Which is a breaking change

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,7 +167,7 @@ for all options. An example:
 
 ```javascript
 const options = {
-  frontEndOptions: {
+  frontendOptions: {
     showHelper: true,
     translations: {
       helper: 'Hello world 🌍'

--- a/src/irma-web-glue.js
+++ b/src/irma-web-glue.js
@@ -10,7 +10,7 @@ export default class IrmaWebGlue {
     this._stateMachine = new StateMachine();
     this._stateMachine.addStateChangeListener((s) => this._stateChangeListener(s));
 
-    this._frontend     = new options.frontend(this._stateMachine, element, options.frontEndOptions);
+    this._frontend     = new options.frontend(this._stateMachine, element, options.frontendOptions);
     this._backend      = new options.backend(this._stateMachine, (r) => this._flowResult = r, options.backendOptions);
   }
 
@@ -18,7 +18,7 @@ export default class IrmaWebGlue {
     return Object.assign({
       frontend: frontends.IrmaWeb,
       backend:  backends.IrmaJS,
-      frontEndOptions: {},
+      frontendOptions: {},
       backendOptions:  {}
     }, options);
   }


### PR DESCRIPTION
"Frontend" and "backend" are written with a lower case letter "e" everywhere, except here.

This changes the API of IrmaWebGlue for the user. Let's put this at least in a minor update.